### PR TITLE
春A-C、夏季、秋A-C、春季、通年の順番にマッチングするように変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twinte-parser",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Twinte内部で使用するために開発されたKdBパーサ",
   "private": false,
   "main": "dist/index.js",

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,7 +4,7 @@ import parse from './parser'
 import * as colors from 'colors'
 import * as commandLineArgs from 'command-line-args'
 
-console.log('twinte-parser v0.0.1'.green.bold)
+console.log('twinte-parser v1.3.2'.green.bold)
 
 const ops = commandLineArgs([
   { name: 'year', alias: 'y', defaultValue: undefined }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -60,12 +60,7 @@ const analyzeDayAndPeriod = (str: string): { day: Day; period: number }[] => {
  */
 const analyzeModule = (str: string): Module[] => {
   const result: Module[] = []
-
-  // 特殊系のマッチング（通年、夏季休業中、春季休業中）
-  if (str.includes(Module.Annual)) result.push(Module.Annual)
-  if (str.includes(Module.SpringVacation)) result.push(Module.SpringVacation)
-  if (str.includes(Module.SummerVacation)) result.push(Module.SummerVacation)
-
+  
   /*
   /春[ABC]*A/は春A 春AB 春ABCに
   /春[ABC]*B/は春B 春AB 春BCに
@@ -74,10 +69,15 @@ const analyzeModule = (str: string): Module[] => {
   if (/春[ABC]*A/gm.test(str)) result.push(Module.SpringA)
   if (/春[ABC]*B/gm.test(str)) result.push(Module.SpringB)
   if (/春[ABC]*C/gm.test(str)) result.push(Module.SpringC)
-
+  
   if (/秋[ABC]*A/gm.test(str)) result.push(Module.FallA)
   if (/秋[ABC]*B/gm.test(str)) result.push(Module.FallB)
   if (/秋[ABC]*C/gm.test(str)) result.push(Module.FallC)
+
+  // 特殊系のマッチング（通年、夏季休業中、春季休業中）
+  if (str.includes(Module.Annual)) result.push(Module.Annual)
+  if (str.includes(Module.SpringVacation)) result.push(Module.SpringVacation)
+  if (str.includes(Module.SummerVacation)) result.push(Module.SummerVacation)
 
   //どのモジュールにも判定されなかったが空文字ではない場合、仮にunknownとする
   if (str !== '' && result.length === 0) result.push(Module.Unknown)

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -60,6 +60,7 @@ const analyzeDayAndPeriod = (str: string): { day: Day; period: number }[] => {
  */
 const analyzeModule = (str: string): Module[] => {
   const result: Module[] = []
+
   
   /*
   /春[ABC]*A/は春A 春AB 春ABCに
@@ -70,15 +71,17 @@ const analyzeModule = (str: string): Module[] => {
   if (/春[ABC]*B/gm.test(str)) result.push(Module.SpringB)
   if (/春[ABC]*C/gm.test(str)) result.push(Module.SpringC)
   
-  // 春季休業中のマッチング
-  if (str.includes(Module.SpringVacation)) result.push(Module.SpringVacation)
+  // 夏季休業中、通年のマッチング
+  if (str.includes(Module.SummerVacation)) result.push(Module.SummerVacation)
 
   if (/秋[ABC]*A/gm.test(str)) result.push(Module.FallA)
   if (/秋[ABC]*B/gm.test(str)) result.push(Module.FallB)
   if (/秋[ABC]*C/gm.test(str)) result.push(Module.FallC)
+  
+  // 春季休業中のマッチング
+  if (str.includes(Module.SpringVacation)) result.push(Module.SpringVacation)
 
-  // 秋季休業中、通年のマッチング
-  if (str.includes(Module.SummerVacation)) result.push(Module.SummerVacation)
+  // 通年のマッチング
   if (str.includes(Module.Annual)) result.push(Module.Annual)
 
   //どのモジュールにも判定されなかったが空文字ではない場合、仮にunknownとする

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -70,14 +70,16 @@ const analyzeModule = (str: string): Module[] => {
   if (/春[ABC]*B/gm.test(str)) result.push(Module.SpringB)
   if (/春[ABC]*C/gm.test(str)) result.push(Module.SpringC)
   
+  // 春季休業中のマッチング
+  if (str.includes(Module.SpringVacation)) result.push(Module.SpringVacation)
+
   if (/秋[ABC]*A/gm.test(str)) result.push(Module.FallA)
   if (/秋[ABC]*B/gm.test(str)) result.push(Module.FallB)
   if (/秋[ABC]*C/gm.test(str)) result.push(Module.FallC)
 
-  // 特殊系のマッチング（通年、夏季休業中、春季休業中）
-  if (str.includes(Module.Annual)) result.push(Module.Annual)
-  if (str.includes(Module.SpringVacation)) result.push(Module.SpringVacation)
+  // 秋季休業中、通年のマッチング
   if (str.includes(Module.SummerVacation)) result.push(Module.SummerVacation)
+  if (str.includes(Module.Annual)) result.push(Module.Annual)
 
   //どのモジュールにも判定されなかったが空文字ではない場合、仮にunknownとする
   if (str !== '' && result.length === 0) result.push(Module.Unknown)


### PR DESCRIPTION
[学年暦](https://www.tsukuba.ac.jp/campuslife/calendar/)に従い、春A-C、夏季、秋A-C、春季、通年の順番にマッチするように変更しました。[この処理](https://github.com/twin-te/twinte-front/pull/199)を行うときに順番が学年暦の時系列順だと嬉しいからです。

具体的には、いままで生物資源科学研究法などのdetailsは
```
[{ module: '春A', period: 4, day: '金', room: '3A304' },
 { module: '春B', period: 4, day: '金', room: '3A304' },
 { module: '夏季休業中', period: 0, day: '集中', room: '3A304' },
 { module: '春C', period: 0, day: '集中', room: '3A304' } ]
```
と時系列がバラバラになっていたため
```
[{ module: '春A', period: 4, day: '金', room: '3A304' },
 { module: '春B', period: 4, day: '金', room: '3A304' },
 { module: '春C', period: 0, day: '集中', room: '3A304' },
 { module: '夏季休業中', period: 0, day: '集中', room: '3A304' }]
```
のように春xが夏季休業などの特殊系よりも前にくるように変更しました。